### PR TITLE
Add simple test launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/test/cargo-test-cerussite/target
 /test/cerussite-test-tool/target
 /test/test-src/ok/*
 /test/test-src/ng/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /test/cargo-test-cerussite/target
 /test/cerussite-test-tool/target
+/test/cargo-run-test/target
 /test/test-src/ok/*
 /test/test-src/ng/*
 !/test/test-src/ok/*.c

--- a/test/cargo-test-cerussite/Cargo.lock
+++ b/test/cargo-test-cerussite/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "cargo-run-test"
+version = "0.1.0"
+

--- a/test/cargo-test-cerussite/Cargo.lock
+++ b/test/cargo-test-cerussite/Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
-name = "cargo-run-test"
+name = "cargo-test-cerussite"
 version = "0.1.0"
 

--- a/test/cargo-test-cerussite/Cargo.toml
+++ b/test/cargo-test-cerussite/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-test-cerussite"
+version = "0.1.0"
+authors = ["statiolake <statiolake@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/test/cargo-test-cerussite/Cargo.toml
+++ b/test/cargo-test-cerussite/Cargo.toml
@@ -2,6 +2,5 @@
 name = "cargo-test-cerussite"
 version = "0.1.0"
 authors = ["statiolake <statiolake@gmail.com>"]
-edition = "2018"
 
 [dependencies]

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -5,9 +5,10 @@ use std::process::Command;
 
 fn main() -> io::Result<()> {
     let root = find_project_root()?;
-    eprintln!("found project root at {}", root.display());
+    eprintln!("> found project root at {}", root.display());
 
     // build test tool
+    eprintln!("> building test tool");
     Command::new("cargo")
         .arg("build")
         .arg("--release")
@@ -21,6 +22,7 @@ fn main() -> io::Result<()> {
     assert_eq!(args.next(), Some("test-cerussite".into()));
 
     // run test tool
+    eprintln!("> running test");
     Command::new(root.join("test/cerussite-test-tool/target/release/cerussite-test-tool"))
         .args(args)
         .current_dir(root)

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -9,20 +9,32 @@ fn main() -> io::Result<()> {
 
     // build test tool
     eprintln!("> building test tool");
-    Command::new("cargo")
+    let res = Command::new("cargo")
         .arg("build")
         .arg("--release")
         .current_dir(root.join("test/cerussite-test-tool"))
         .spawn()?
         .wait()?;
+    if !res.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "building test tool failed.",
+        ));
+    }
 
     // build cerussite
     eprintln!("> building cerussite");
-    Command::new("cargo")
+    let res = Command::new("cargo")
         .arg("build")
         .current_dir(&root)
         .spawn()?
         .wait()?;
+    if !res.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "building cerussite failed.",
+        ));
+    }
 
     // run test tool
     eprintln!("> running test");
@@ -31,11 +43,18 @@ fn main() -> io::Result<()> {
     assert_eq!(args.next().map(|x| x.contains("cargo")), Some(true));
     assert_eq!(args.next(), Some("test-cerussite".into()));
 
-    Command::new(root.join("test/cerussite-test-tool/target/release/cerussite-test-tool"))
-        .args(args)
-        .current_dir(root)
-        .spawn()?
-        .wait()?;
+    let res =
+        Command::new(root.join("test/cerussite-test-tool/target/release/cerussite-test-tool"))
+            .args(args)
+            .current_dir(root)
+            .spawn()?
+            .wait()?;
+    if !res.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "runnning test failed.",
+        ));
+    }
 
     Ok(())
 }

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -16,13 +16,13 @@ fn main() -> io::Result<()> {
         .spawn()?
         .wait()?;
 
+    // run test tool
+    eprintln!("> running test");
     let mut args = env::args();
 
     assert_eq!(args.next().map(|x| x.contains("cargo")), Some(true));
     assert_eq!(args.next(), Some("test-cerussite".into()));
 
-    // run test tool
-    eprintln!("> running test");
     Command::new(root.join("test/cerussite-test-tool/target/release/cerussite-test-tool"))
         .args(args)
         .current_dir(root)

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -16,6 +16,14 @@ fn main() -> io::Result<()> {
         .spawn()?
         .wait()?;
 
+    // build cerussite
+    eprintln!("> building cerussite");
+    Command::new("cargo")
+        .arg("build")
+        .current_dir(&root)
+        .spawn()?
+        .wait()?;
+
     // run test tool
     eprintln!("> running test");
     let mut args = env::args();

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io;
 use std::process::Command;
 
@@ -7,6 +8,17 @@ fn main() -> io::Result<()> {
         .arg("build")
         .arg("--release")
         .current_dir("test/cerussite-test-tool")
+        .spawn()?
+        .wait()?;
+
+    let mut args = env::args();
+
+    assert_eq!(args.next().map(|x| x.contains("cargo")), Some(true));
+    assert_eq!(args.next(), Some("test-cerussite".into()));
+
+    // run test tool
+    Command::new("test/cerussite-test-tool/target/release/cerussite-test-tool")
+        .args(args)
         .spawn()?
         .wait()?;
 

--- a/test/cargo-test-cerussite/src/main.rs
+++ b/test/cargo-test-cerussite/src/main.rs
@@ -1,3 +1,14 @@
-fn main() {
-    println!("Hello, world!");
+use std::io;
+use std::process::Command;
+
+fn main() -> io::Result<()> {
+    // build test tool
+    Command::new("cargo")
+        .arg("build")
+        .arg("--release")
+        .current_dir("test/cerussite-test-tool")
+        .spawn()?
+        .wait()?;
+
+    Ok(())
 }


### PR DESCRIPTION
#16 を受けて、テストツールを実行するランチャーを作ってみました。

`test/cargo-test-cerussite` がツールです。このツールのバイナリをパスの通った場所に置くか、インストール (`cargo install --path . --force`) すると `cargo test-cerussite` というサブコマンドが使えるようになります。

`cargo test-cerussite` は、テストツールをコンパイルし、 cerussite 自体をコンパイルし、テストツールを呼び出します。テストツールのコンパイルまたは cerussite のコンパイルに失敗した場合、テストを含む以降の処理は中断されます。テストツール本体をインストールする必要はありません。このランチャーは、 cerussite-test-tool を `build --release` でコンパイルして、コンパイル済みバイナリを直接実行します。ランチャーが勝手に cerussite-test-tool をインストールすることもありません。

`cargo test-cerussite` はプロジェクトのルートディレクトリで実行する必要はありません。カレントディレクトリから上へ上へ辿って最初に `Cargo.toml` が見つかったディレクトリをプロジェクトのルートと判定し、そこを基準に各ディレクトリを計算して実行します。これにより、たとえば /src 以下で作業をしていても、その場で `cargo test-cerussite` を実行すればよしなにテストを実行してくれます。そのかわり cargo-test-cerussite のディレクトリで実行してしまうと、そこをルートとみなしてしまってエラーを起こすので、インストール後は一度親ディレクトリへ上がってから実行してください。

`cargo test-cerussite` に続けて渡されるコマンドライン引数はそのまま cerussite-test-tool へ流されます。ファイル名の指定機能、冗長表示機能 `-v` も正しく実行できます。

Close #16 