### PR TITLE
Introduce Cell

### DIFF
--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -7,8 +7,8 @@ enum Value<'a> {
 }
 #[test]
 fn test_value() {
-    let mut a = IdentityGenerator::new();
-    let b = Register::new(&mut a);
+    let a = IdentityGenerator::new();
+    let b = Register::new(&a);
     let _c = Value::Constant(0);
     let _d = Value::Register(&b);
 }
@@ -21,7 +21,7 @@ impl<'a> Instruction<'a> {
     fn ret(val: Value) -> Instruction {
         Instruction::Ret(val)
     }
-    fn add(gen: &'a mut IdentityGenerator,
+    fn add(gen: &'a IdentityGenerator,
            lhs: Value<'a>, rhs: Value<'a>) -> Instruction<'a> {
         let reg = Register::new(gen);
         Instruction::Add(reg, lhs, rhs)
@@ -35,10 +35,10 @@ impl<'a> Instruction<'a> {
 }
 #[test]
 fn test_instruction() {
-    let mut gen = IdentityGenerator::new();
+    let gen = IdentityGenerator::new();
     let val1 = Value::Constant(1);
     let val2 = Value::Constant(2);
-    let add = Instruction::add(&mut gen, val1, val2);
+    let add = Instruction::add(&gen, val1, val2);
     let val3 = Instruction::target(&add).unwrap();
     let _ret = Instruction::ret(val3);
 }

--- a/src/ir/instruction.rs
+++ b/src/ir/instruction.rs
@@ -1,0 +1,44 @@
+use super::register::IdentityGenerator;
+use super::register::Register;
+
+enum Value<'a> {
+    Constant(i32),
+    Register(&'a Register),
+}
+#[test]
+fn test_value() {
+    let mut a = IdentityGenerator::new();
+    let b = Register::new(&mut a);
+    let _c = Value::Constant(0);
+    let _d = Value::Register(&b);
+}
+
+enum Instruction<'a> {
+    Ret(Value<'a>),
+    Add(Register, Value<'a>, Value<'a>),
+}
+impl<'a> Instruction<'a> {
+    fn ret(val: Value) -> Instruction {
+        Instruction::Ret(val)
+    }
+    fn add(gen: &'a mut IdentityGenerator,
+           lhs: Value<'a>, rhs: Value<'a>) -> Instruction<'a> {
+        let reg = Register::new(gen);
+        Instruction::Add(reg, lhs, rhs)
+    }
+    fn target(inst: &'a Instruction) -> Option<Value<'a>> {
+        match inst {
+            Instruction::Ret(_) => None,
+            Instruction::Add(target, _, _) => Some(Value::Register(&target)),
+        }
+    }
+}
+#[test]
+fn test_instruction() {
+    let mut gen = IdentityGenerator::new();
+    let val1 = Value::Constant(1);
+    let val2 = Value::Constant(2);
+    let add = Instruction::add(&mut gen, val1, val2);
+    let val3 = Instruction::target(&add).unwrap();
+    let _ret = Instruction::ret(val3);
+}

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,1 +1,2 @@
 mod register;
+mod instruction;

--- a/src/ir/register.rs
+++ b/src/ir/register.rs
@@ -27,13 +27,13 @@ impl IdentityGenerator {
         let id = Identity::new();
         IdentityGenerator(id)
     }
-    fn generate(&mut self) -> Identity {
+    fn generate(&self) -> Identity {
         self.0.next()
     }
 }
 #[test]
 fn test_identity_generator() {
-    let mut a = IdentityGenerator::new();
+    let a = IdentityGenerator::new();
     let b = a.generate();
     let c = a.generate();
     assert_ne!(b, c);
@@ -48,14 +48,14 @@ impl PartialEq for Register {
 }
 impl Eq for Register {}
 impl Register {
-    pub fn new(gen: &mut IdentityGenerator) -> Register {
+    pub fn new(gen: &IdentityGenerator) -> Register {
         Register(gen.generate())
     }
 }
 #[test]
 fn test_register() {
-    let mut a = IdentityGenerator::new();
-    let b = Register::new(&mut a);
-    let c = Register::new(&mut a);
+    let a = IdentityGenerator::new();
+    let b = Register::new(&a);
+    let c = Register::new(&a);
     assert_ne!(b, c);
 }

--- a/src/ir/register.rs
+++ b/src/ir/register.rs
@@ -3,6 +3,9 @@ use std::cell::Cell;
 #[derive(Debug, Eq, PartialEq)]
 struct Identity(Cell<i32>);
 impl Identity {
+    fn new() -> Identity {
+        Identity(Cell::new(0))
+    }
     fn next(&self) -> Identity {
         let prev = self.0.get();
         self.0.set(prev + 1);
@@ -11,8 +14,8 @@ impl Identity {
 }
 #[test]
 fn test_identity() {
-    let a = Identity(Cell::new(0));
-    let b = Identity(Cell::new(0));
+    let a = Identity::new();
+    let b = Identity::new();
     let c = b.next();
     assert_ne!(a, b);
     assert_eq!(a, c);
@@ -21,7 +24,7 @@ fn test_identity() {
 pub struct IdentityGenerator(Identity);
 impl IdentityGenerator {
     pub fn new() -> IdentityGenerator {
-        let id = Identity(Cell::new(0));
+        let id = Identity::new();
         IdentityGenerator(id)
     }
     fn generate(&mut self) -> Identity {

--- a/src/ir/register.rs
+++ b/src/ir/register.rs
@@ -1,16 +1,18 @@
+use std::cell::Cell;
+
 #[derive(Debug, Eq, PartialEq)]
-struct Identity(i32);
+struct Identity(Cell<i32>);
 impl Identity {
-    fn next(&mut self) -> Identity {
-        let prev = self.0;
-        self.0 += 1;
-        Identity(prev)
+    fn next(&self) -> Identity {
+        let prev = self.0.get();
+        self.0.set(prev + 1);
+        Identity(Cell::new(prev))
     }
 }
 #[test]
 fn test_identity() {
-    let a = Identity(0);
-    let mut b = Identity(0);
+    let a = Identity(Cell::new(0));
+    let b = Identity(Cell::new(0));
     let c = b.next();
     assert_ne!(a, b);
     assert_eq!(a, c);
@@ -19,7 +21,7 @@ fn test_identity() {
 pub struct IdentityGenerator(Identity);
 impl IdentityGenerator {
     pub fn new() -> IdentityGenerator {
-        let id = Identity(0);
+        let id = Identity(Cell::new(0));
         IdentityGenerator(id)
     }
     fn generate(&mut self) -> Identity {

--- a/src/ir/register.rs
+++ b/src/ir/register.rs
@@ -16,9 +16,9 @@ fn test_identity() {
     assert_eq!(a, c);
 }
 
-struct IdentityGenerator(Identity);
+pub struct IdentityGenerator(Identity);
 impl IdentityGenerator {
-    fn new() -> IdentityGenerator {
+    pub fn new() -> IdentityGenerator {
         let id = Identity(0);
         IdentityGenerator(id)
     }
@@ -35,7 +35,7 @@ fn test_identity_generator() {
 }
 
 #[derive(Debug)]
-struct Register(Identity);
+pub struct Register(Identity);
 impl PartialEq for Register {
     fn eq(&self, other: &Register) -> bool {
         self.0 == other.0
@@ -43,7 +43,7 @@ impl PartialEq for Register {
 }
 impl Eq for Register {}
 impl Register {
-    fn new(gen: &mut IdentityGenerator) -> Register {
+    pub fn new(gen: &mut IdentityGenerator) -> Register {
         Register(gen.generate())
     }
 }


### PR DESCRIPTION
`Identity` に `Cell` を使って immutable reference で使えるようにする。